### PR TITLE
feat: do not fail when .env is missing

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package memogram
 
 import (
+	"os"
 	"github.com/caarlos0/env"
 	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
@@ -12,9 +13,12 @@ type Config struct {
 }
 
 func getConfigFromEnv() (*Config, error) {
-	err := godotenv.Load(".env")
-	if err != nil {
-		panic(err.Error())
+	envFileName := ".env"
+	if _, err := os.Stat(envFileName); err == nil {
+		err := godotenv.Load(envFileName)
+		if err != nil {
+			panic(err.Error())
+		}
 	}
 
 	config := Config{}


### PR DESCRIPTION
- Bot should not panic on missing .env file and use existing variables instead (usefull for Docker deployment).