### PR TITLE
fix: "forwarded from" string formatting 

### DIFF
--- a/memogram.go
+++ b/memogram.go
@@ -129,7 +129,7 @@ func (s *Service) handler(ctx context.Context, b *bot.Bot, m *models.Update) {
 		if originUsername != "" {
 			content = fmt.Sprintf("Forwarded from [%s](https://t.me/%s)\n%s", originName, originUsername, content)
 		} else {
-			content = fmt.Sprintf("%s\n---\nForwarded from %s", originName, content)
+			content = fmt.Sprintf("Forwarded from %s\n%s", originName, content)
 		}
 	}
 


### PR DESCRIPTION
Recent changes made in [this commit](https://github.com/usememos/telegram-integration/commit/9b9b7b694ec87738e6bc64e93cc2b1385e1143ac#diff-b549a79716ab7a944634cb067625849fab2320d7c847f2997c12b844f722d6d0R132) introduced a string formatting bug.

The modified string
```go
content = fmt.Sprintf("%s\n---\nForwarded from %s", originName, content)
```
resulted in the following formatted string:
```
Du Rove's Channel
---
Forwarded from MEMO_CONTENT
```

I've fixed it by reverting the changes to the original state, as it was in my PR prior to the recent commit. I've also removed a colon according to the formatting changes were made. 

The corrected string now is:
```go
content = fmt.Sprintf("Forwarded from %s\n%s", originName, content)
```
An example of the formatted string is:
```
Forwarded from Du Rove's Channel
MEMO_CONTENT
```