### PR TITLE
feat: add ACCESS_TOKEN in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 SERVER_ADDR=dns:localhost:5230
 BOT_TOKEN=your_bot_token
+ACCESS_TOKEN=userId:access_token

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 SERVER_ADDR=dns:localhost:5230
 BOT_TOKEN=your_bot_token
-ACCESS_TOKEN=userId:access_token
+ACCESS_TOKEN=telegram_userId:access_token

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ Create a `.env` file in the project's root directory and add the following confi
 ```env
 SERVER_ADDR=dns:localhost:5230
 BOT_TOKEN=your_telegram_bot_token
+ACCESS_TOKEN=telegram_userId:access_token
 ```
 
 The `SERVER_ADDR` should be a gRPC server address that the Memos is running on. It follows the [gRPC Name Resolution](https://github.com/grpc/grpc/blob/master/doc/naming.md).
+
+`ACCESS_TOKEN` keeps the telegram bot logged in after a memogram reboot. You can get `telegram_userId` from [@userinfobot](https://t.me/userinfobot).
 
 ## Usage
 

--- a/config.go
+++ b/config.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Config struct {
-	ServerAddr string `env:"SERVER_ADDR,required"`
-	BotToken   string `env:"BOT_TOKEN,required"`
+	ServerAddr  string `env:"SERVER_ADDR,required"`
+	BotToken    string `env:"BOT_TOKEN,required"`
+	AccessToken string `env:"ACCESS_TOKEN"`
 }
 
 func getConfigFromEnv() (*Config, error) {

--- a/memogram.go
+++ b/memogram.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -58,6 +59,21 @@ func NewService() (*Service, error) {
 		return nil, errors.Wrap(err, "failed to create bot")
 	}
 	s.bot = b
+
+	if config.AccessToken != "" {
+		parts := strings.Split(config.AccessToken, ":")
+		if len(parts) == 2 {
+			userIDStr := parts[0]
+			accessToken := parts[1]
+			userID, err := strconv.ParseInt(userIDStr, 10, 64)
+			if err != nil {
+				slog.Error("failed to parse userID to int64", slog.String("userID", userIDStr))
+				return nil, err
+			}
+			userAccessTokenCache.Store(userID, accessToken)
+			slog.Info("load accessToken", slog.Any("userID", userID))
+		}
+	}
 
 	return s, nil
 }


### PR DESCRIPTION
Add ACCESS_TOKEN to .env.example and read it in NewService function.

* **config.go**
  - Add `AccessToken` field to `Config` struct.
  - Parse and load `ACCESS_TOKEN` from the environment in `getConfigFromEnv` function.

* **memogram.go**
  - Read `ACCESS_TOKEN` from the configuration in `NewService` function.
  - If `ACCESS_TOKEN` is not blank, split it with `:`, get `userId` and `access_token`, and store them in `userAccessTokenCache`.

* **.env.example**
  - Add `ACCESS_TOKEN` variable in the format `userId:access_token`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wolfsilver/telegram-integration?shareId=115c59c8-ef60-4040-8f4e-e2b420f4bca4).

Fixes  https://github.com/usememos/telegram-integration/issues/25