### PR TITLE
Fix nil pointer panic

### DIFF
--- a/memogram.go
+++ b/memogram.go
@@ -140,6 +140,10 @@ func (s *Service) handleMemoCreation(ctx context.Context, m *models.Update, cont
 }
 
 func (s *Service) handler(ctx context.Context, b *bot.Bot, m *models.Update) {
+	if m.Message == nil {
+		slog.Info("memo message is nil")
+		return
+	}
 	message := m.Message
 	if strings.HasPrefix(message.Text, "/start ") {
 		s.startHandler(ctx, b, m)


### PR DESCRIPTION
When receiving an update from the Telegram API that is not related to a new message, the app crashes with a nil pointer error. This happens because the code assumes that every update has a non-nil Message field, which is not always the case.

Change Description:
	•	Added a condition to check if the Message field in the update is nil.
	•	Logged a message (“memo message is nil”) and safely returned early when the condition is met.
	•	This prevents the app from crashing due to a nil pointer error when the update is not about a new message.

Impact:
	•	Ensures the app handles updates without a Message field gracefully.
	•	Improves the app’s robustness by avoiding unnecessary panics.