### PR TITLE
Helper message for commands

### DIFF
--- a/memogram.go
+++ b/memogram.go
@@ -148,7 +148,19 @@ func (s *Service) handler(ctx context.Context, b *bot.Bot, m *models.Update) {
 		return
 	}
 	message := m.Message
-	if strings.HasPrefix(message.Text, "/start ") {
+	if strings.EqualFold(message.Text, "/start") {
+		b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: message.Chat.ID,
+			Text:   "Please provide the access token: /start <access_token>",
+		})
+		return
+	} else if strings.EqualFold(message.Text, "/search") {
+		b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: message.Chat.ID,
+			Text:   "Usage: /search <search_string>",
+		})
+		return
+	} else if strings.HasPrefix(message.Text, "/start ") {
 		s.startHandler(ctx, b, m)
 		return
 	} else if strings.HasPrefix(message.Text, "/search ") {


### PR DESCRIPTION
Telegram UI suggests commands, and by clicking on them the command is sent to the bot.
For start and search command, when these buttons are clicked, an unwanted memo will be created.

Change Description:
- Adding two more checks for the commands in `handler` to match the `/start` and `/search`

Impact:
- Respond with command usage instruction when just a command is sent to the bot

![image](https://github.com/user-attachments/assets/0c845059-83a6-4c29-8a6d-3b243b40000c)
