### PR TITLE
Create release-docker-image.yml

### DIFF
--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -1,0 +1,52 @@
+name: Release - docker image
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+# permissions are needed if pushing to ghcr.io
+permissions: 
+  packages: write
+
+jobs:
+  build_push:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    steps:
+      # Get the repository's code
+      - uses: actions/checkout@v4
+      # https://github.com/docker/setup-qemu-action
+      - uses: docker/setup-qemu-action@v3
+      # https://github.com/docker/setup-buildx-action
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository }}
+          # Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      
+      - name: Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I think we could benefit from automation for creating `docker image`.
This will save me and other users from manually building the image.
To work, you need to enable the `registry` function in the repository settings.
```
Workflow permissions = Read and write permissions
```

I checked the build on `v0.2.4`.
