### PR TITLE
Upgrade the Memogram to newest version of api of memos (0.25.3)

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	BotProxyAddr     string `env:"BOT_PROXY_ADDR"`
 	Data             string `env:"DATA"`
 	AllowedUsernames string `env:"ALLOWED_USERNAMES"`
+	InstanceURL      string `env:"INSTANCE_URL"`
 }
 
 func getConfigFromEnv() (*Config, error) {


### PR DESCRIPTION
Hi, I was setting telegram integration for my memo of newest version and found following patches required.

- Drop deprecated `ListMemosRequest.Parent` field usage.
- Add `INSTANCE_URL` fallback when `WorkspaceService` is unavailable to keep memo links working.